### PR TITLE
initial vagrantfile and work in progress provisioning scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.define "centos" do |centos|
+    centos.vm.box = "centos/8"
+    centos.vm.box_version = "1905.1"
+    centos.vm.network "forwarded_port", guest: 8080, host: 18080
+    centos.vm.provision :shell, path: "provision/centos.sh"
+  end
+
+  config.vm.define "ubuntu" do |ubuntu|
+    ubuntu.vm.box = "bento/ubuntu-20.04"
+    ubuntu.vm.network "forwarded_port", guest: 8080, host: 28080
+    ubuntu.vm.provision :shell, path: "provision/ubuntu.sh"
+  end
+end

--- a/provision/centos.sh
+++ b/provision/centos.sh
@@ -1,0 +1,3 @@
+# TODO: currently pulls down 1.13 but we want to use latest
+sudo yum module list go-toolset
+sudo yum module -y install go-toolset

--- a/provision/ubuntu.sh
+++ b/provision/ubuntu.sh
@@ -1,0 +1,2 @@
+# TODO: currently installs 1.13 but we want this to pull down latest
+sudo apt install -y golang


### PR DESCRIPTION
A simple PR to add a Vagrantfile for manual acceptance testing. This is a work in progress, the provision scripts should install the latest go instead of the distro default version (which is currently 1.13).