### PR TITLE
SPEED-625 Disable request source

### DIFF
--- a/views/pages/ssrf.gohtml
+++ b/views/pages/ssrf.gohtml
@@ -26,7 +26,7 @@
         <button type="submit" class="btn btn-warning">http</button>
         </li>
         <li id="request-selection">
-        <button type="submit" class="btn btn-warning">request</button>
+        <button type="submit" class="btn btn-warning" disabled="disabled">request</button>
         </li>
     </ul>
     </div>


### PR DESCRIPTION
First use case is to cover standard library. Afterwards third-party packages will be included.