### PR TITLE
GO-635 Add bytes.Buffer usage in XSS and PathTraversal

### DIFF
--- a/pathtraversal/path-traversal.go
+++ b/pathtraversal/path-traversal.go
@@ -2,11 +2,13 @@ package pathtraversal
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/Contrast-Security-OSS/go-test-bench/utils"
@@ -28,32 +30,31 @@ func pathTTemplate(w http.ResponseWriter, r *http.Request, data utils.Parameters
 	return template.HTML(buf.String()), true
 }
 
-func readFileHandler(w http.ResponseWriter, r *http.Request, method string, inputs string) (template.HTML, bool) {
-	log.Println("Executing pathTraversal readFile ; method = " + method)
+func readFileHandler(w http.ResponseWriter, r *http.Request, method string, inputs string, isBuffered bool) (template.HTML, bool) {
+	log.Printf("Executing pathTraversal readFile ; method = %s ; use of bytes.Buffer = %t\n", method, isBuffered)
 	var data string
+	var err error
 	switch method {
 	case "safe":
 		inputs = url.QueryEscape(inputs)
-		content, err := ioutil.ReadFile(inputs)
+		if isBuffered {
+			data, err = bufferedReadFile(inputs)
+		} else {
+			data, err = readFile(inputs)
+		}
+
 		if err != nil {
 			return template.HTML("Congrats, you are safe! Error from readFile: " + err.Error()), false
 			//fmt.Fprintf(w, "Congrats, you are safe! Error from readFile: ")
 			//http.Error(w, err.Error(),500)
-		} else if string(content) == "" {
+		} else if data == "" {
 			return template.HTML("Congrats, you are safe! No data was read."), false
-		} else {
-			data = string(content)
 		}
 	case "unsafe":
-		content, err := ioutil.ReadFile(inputs)
-		data = string(content)
-		if err != nil {
-			log.Println(err)
-		}
-		if data == "" || err != nil {
-			data = "Done!"
+		if isBuffered {
+			data, err = bufferedReadFile(inputs)
 		} else {
-			data = string(content)
+			data, err = readFile(inputs)
 		}
 	default:
 		data = "INVALID URL"
@@ -61,38 +62,110 @@ func readFileHandler(w http.ResponseWriter, r *http.Request, method string, inpu
 	return template.HTML(data), false
 }
 
-func writeFileHandler(w http.ResponseWriter, r *http.Request, method string, inputs string) (template.HTML, bool) {
-	log.Println("Executing pathTraversal writeFile ; method = " + method)
-	var data string
+// bufferedReadFile read the given file using bytes.Buffer
+func bufferedReadFile(filename string) (string, error) {
+	fr, err := os.Open(filename)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+	defer fr.Close()
+
+	var buf bytes.Buffer
+	buf.ReadFrom(fr)
+
+	return buf.String(), nil
+}
+
+// readFile read the given file using ioutil.ReadFile
+func readFile(filename string) (string, error) {
+	content, err := ioutil.ReadFile(filename)
+	data := string(content)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+	if data == "" || err != nil {
+		data = "Done!"
+	} else {
+		data = string(content)
+	}
+	return data, nil
+}
+
+func writeFileHandler(w http.ResponseWriter, r *http.Request, method string, inputs string, isBuffered bool) (template.HTML, bool) {
+	log.Printf("Executing pathTraversal writeFile ; method =  %s ; use of bytes.Buffer = %t\n", method, isBuffered)
+	var data, message string
+	var err error
 	switch method {
 	case "safe":
 		inputs = url.QueryEscape(inputs)
-		message := []byte("pathTraversal")
-		err := ioutil.WriteFile(inputs, message, 0644)
+		if isBuffered {
+			message = "buffered pathTraversal"
+			err = bufferedWriteFile(inputs, message)
+		} else {
+			message = "pathTraversal"
+			err = writeFile(inputs, message)
+		}
+		data = message
 		if err != nil {
 			return template.HTML("Congrats, you are safe! Error from writeFile: " + err.Error()), false
-		} else if string(message) == "" {
+		} else if data == "" {
 			return template.HTML("Congrats, you are safe! No data was written."), false
 		} else { //something was written!
-			data = "Wrote \"" + string(message) + "\" to: " + inputs
+			data = "Wrote \"" + message + "\" to: " + inputs
 			log.Printf("%s was written with pathTraversal\n", inputs)
 		}
 	case "unsafe":
-		message := []byte("pathTraversal")
-		err := ioutil.WriteFile(inputs, message, 0644)
-		data = string(message)
-		if err != nil {
-			log.Println(err)
+		if isBuffered {
+			message = "buffered pathTraversal"
+			err = bufferedWriteFile(inputs, message)
+		} else {
+			message = "pathTraversal"
+			err = writeFile(inputs, message)
 		}
+		data = message
 		if data == "" || err != nil {
 			data = "Done!"
 		} else {
-			data = "Wrote \"" + data + "\" to: " + inputs
+			data = "Wrote \"" + message + "\" to: " + inputs
 		}
 	default:
 		data = "INVALID URL"
 	}
 	return template.HTML(data), false
+}
+
+// bufferedWriteFile write message content in the given file using bytes.Buffer
+func bufferedWriteFile(filename, message string) error {
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, message)
+
+	fr, err := os.Create(filename)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	defer fr.Close()
+
+	_, err = buf.WriteTo(fr)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	return nil
+}
+
+// bufferedWriteFile write message content in the given file using ioutil.WriteFile
+func writeFile(filename, message string) error {
+	err := ioutil.WriteFile(filename, []byte(message), 0644)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	return nil
 }
 
 //Handler is the API handler for path traversal
@@ -101,20 +174,22 @@ func Handler(w http.ResponseWriter, r *http.Request, pd utils.Parameters) (templ
 	if len(splitURL) < 4 {
 		return pathTTemplate(w, r, pd)
 	}
-	if splitURL[2] != "body" && splitURL[2] != "headers" && splitURL[2] != "query" {
+	if splitURL[2] != "body" && splitURL[2] != "headers" && splitURL[2] != "query" && splitURL[2] != "buffered-query" {
 		return template.HTML("INVALID URL"), false
 	}
 	if splitURL[4] == "noop" {
 		return template.HTML("NOOP"), false
 	}
 
+	isBuffered := strings.Contains(splitURL[2], "buffered")
+
 	userInput := utils.GetUserInput(r)
 
 	switch splitURL[3] {
 	case "ioutil.ReadFile":
-		return readFileHandler(w, r, splitURL[4], userInput)
+		return readFileHandler(w, r, splitURL[4], userInput, isBuffered)
 	case "ioutil.WriteFile":
-		return writeFileHandler(w, r, splitURL[4], userInput)
+		return writeFileHandler(w, r, splitURL[4], userInput, isBuffered)
 	default: //should be an error instead
 		return template.HTML("INVALID URL"), false
 	}

--- a/unvalidated/unvalidated-redirect.go
+++ b/unvalidated/unvalidated-redirect.go
@@ -18,20 +18,20 @@ var templates = template.Must(template.ParseFiles(
 
 func httpRedirectHandler(w http.ResponseWriter, r *http.Request, pd utils.Parameters, splitURL []string) (template.HTML, bool) {
 	mode := splitURL[len(splitURL)-1]
-	formValue := utils.GetUserInput(r)
 
-	if mode == "unsafe" {
+	switch mode {
+	case "safe":
+		formValue := utils.GetUserInput(r)
+		sanitizedURL := url.PathEscape(formValue)
+		http.Redirect(w, r, sanitizedURL, http.StatusFound)
+	case "unsafe":
+		formValue := utils.GetUserInput(r)
 		http.Redirect(w, r, formValue, http.StatusFound)
-
-	} else if mode == "noop" {
+	case "noop":
 		http.Redirect(w, r, "http://www.example.com", http.StatusFound)
-
-	} else if mode == "safe" {
-		sanatizedURL := url.PathEscape(formValue)
-		http.Redirect(w, r, sanatizedURL, http.StatusFound)
 	}
-	return "", false
 
+	return "", false
 }
 
 func unvalidatedTemplate(w http.ResponseWriter, r *http.Request, pd utils.Parameters) (template.HTML, bool) {

--- a/views/pages/pathTraversal.gohtml
+++ b/views/pages/pathTraversal.gohtml
@@ -25,7 +25,7 @@
         </div>
         <button type="submit" class="btn btn-primary">Submit</button>
         </form>
-        <h4 class="sub-header">Buffered Query - <code>bytes.Buffer</code></h4>
+        <h4 class="sub-header">Buffered Query</h4>
         <form method="{{.Method}}" action="{{.URL}}/buffered-{{index $inputs 0}}/{{.Name}}/unsafe" target="_blank">
         <div class="form-group">
             <label for="exampleInputEmail1">Path</label>

--- a/views/pages/pathTraversal.gohtml
+++ b/views/pages/pathTraversal.gohtml
@@ -25,6 +25,18 @@
         </div>
         <button type="submit" class="btn btn-primary">Submit</button>
         </form>
+        <h4 class="sub-header">Buffered Query - <code>bytes.Buffer</code></h4>
+        <form method="{{.Method}}" action="{{.URL}}/buffered-{{index $inputs 0}}/{{.Name}}/unsafe" target="_blank">
+        <div class="form-group">
+            <label for="exampleInputEmail1">Path</label>
+            <input
+            name="input"
+            class="form-control"
+            value="../../../../../../../../../../../../etc/passwd"
+            />
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+        </form>
         <h4 class="sub-header">Headers</h4>
          <!--<% headerSink = groupedSinkData.headers[i] %> -->
         <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/{{.Name}}/unsafe -H "input: ../../../../../../../../../../../../etc/passwd"</pre></p>

--- a/views/pages/xss.gohtml
+++ b/views/pages/xss.gohtml
@@ -36,6 +36,38 @@
 </div>
 <div class="row">
   <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
+    <h4 class="sub-header">Buffered Query</h4>
+    <p>
+      <a
+        id = "queryunsafehere"
+        target="_blank"
+        href="/xss/buffered-query/reflectedXss/unsafe"
+        >
+        /xss/buffered-query/reflectedXss/unsafe
+      </a>
+    </p>
+    <p>
+      <a
+        id = "querysafehere"
+        target="_blank"
+        href="/xss/buffered-query/reflectedXss/safe"
+        >
+        /xss/buffered-query/reflectedXss/safe
+      </a>
+    </p>
+    <p>
+      <a
+        id = "querynoophere"
+        target="_blank"
+        href="/xss/buffered-query/reflectedXss/noop"
+        >
+        /xss/buffered-query/reflectedXss/noop
+      </a>
+    </p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
     <h4 class="sub-header">Params</h4>
     <!--<% groupedSinkData.params.forEach(function(sink) { %>-->
    <!-- <% ['unsafe', 'safe', 'noop'].forEach(function(safety) { %>-->
@@ -77,6 +109,22 @@
                 name="input"
                 class="form-control"
                 value="&lt;script&gt;alert(1);&lt;/script&gt;"
+        />
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
+    <form method="POST" action="/xss/buffered-body/reflectedXss/unsafe" target="_blank">
+      <div class="form-group">
+        <label for="">Buffered input</label>
+        <input type="hidden" value="buffered_input" />
+        <input
+                name="input"
+                class="form-control"
+                value="&lt;script&gt;alert('buffered input - &copy;');&lt;/script&gt;"
         />
       </div>
       <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
This PR affects XSS and PathTraversal. At both places different approach is taken and specific methods are covered.
 - **in XSS:**
     * created additional endpoint `buffered-query` which ignores the user input and set the query input explicitly.
        _Covered methods:_   
        ```
        Write(…)
        WriteByte(…)
        WriteRune(…) 
        WriteString(…)
        Bytes()
        ```
     * created additional endpoint `buffered-body` which initialises the buffer from the user input.
        _Covered methods:_   
        ```
        NewBufferString(utils.GetUserInput(r))
        String()
        ```
- **in PathTraversal:**
     * created additional endpoint `buffered-query` which defines whether to use bytes.Buffer for reading or writing a file. Additional functions are created to separate read/write from read/write with a buffer.
        _Covered methods:_ 
        ```
        ReadFrom(...)
        String()
        WriteTo(...)
        ```

### Testing
Build and run the **go-test-bench** app. Log messages should be updated with indication whether bytes.Buffer is used or not and the app should work as expected without errors.