### PR TITLE
GO-641 Add new sqli endpoint with json struct

### DIFF
--- a/sqli/sql-injection.go
+++ b/sqli/sql-injection.go
@@ -43,7 +43,9 @@ func headersHandler(w http.ResponseWriter, r *http.Request, routeInfo utils.Rout
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}
-	err := json.Unmarshal([]byte(r.Header.Get("credentials")), &credentials)
+	rawCredentials := r.Header.Get("credentials")
+	credBytes := []byte(rawCredentials)
+	err := json.Unmarshal(credBytes, &credentials)
 	if err != nil {
 		log.Printf("Could not parse headers to json, err = %s", err)
 	}
@@ -81,7 +83,7 @@ func setupSqlite3() (*sql.DB, error) {
 	return sqlite3Database, nil
 }
 
-func getSqliteSafetyQuery(db *sql.DB, userInput, safety string) string{
+func getSqliteSafetyQuery(db *sql.DB, userInput, safety string) string {
 	var query string
 	switch safety {
 	case "unsafe":

--- a/sqli/sql-injection.go
+++ b/sqli/sql-injection.go
@@ -3,6 +3,7 @@ package sqli
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"github.com/Contrast-Security-OSS/go-test-bench/utils"
 	// database import for sqlite3
@@ -21,10 +22,10 @@ var templates = template.Must(template.ParseFiles(
 	"./views/partials/ruleInfo.gohtml",
 ))
 
-func sqliTemplate(w http.ResponseWriter, r *http.Request, routeInfo utils.Route) (template.HTML, bool) {
+func sqliTemplate(w http.ResponseWriter, r *http.Request, params utils.Parameters) (template.HTML, bool) {
 	var buf bytes.Buffer
 
-	err := templates.ExecuteTemplate(&buf, "sqlInjection", routeInfo)
+	err := templates.ExecuteTemplate(&buf, "sqlInjection", params)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -32,39 +33,86 @@ func sqliTemplate(w http.ResponseWriter, r *http.Request, routeInfo utils.Route)
 
 }
 
-func sqlite3Handler(w http.ResponseWriter, r *http.Request, routeInfo utils.Route, splitURL []string) (template.HTML, bool) {
+func headersHandler(w http.ResponseWriter, r *http.Request, routeInfo utils.Route, splitURL []string) (template.HTML, bool) {
+	// Currently we pass only json credentials in headers for SQL Injection
+	if splitURL[3] != "json" {
+		return template.HTML("INVALID URL"), false
+	}
+
+	var credentials struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	err := json.Unmarshal([]byte(r.Header.Get("credentials")), &credentials)
+	if err != nil {
+		log.Printf("Could not parse headers to json, err = %s", err)
+	}
+
+	// setting up a database to execute the built query
+	var sqlite3Database *sql.DB
+	sqlite3Database, err = setupSqlite3()
+	if err != nil {
+		return template.HTML(err.Error()), false
+	}
+	defer func() {
+		_ = sqlite3Database.Close()
+	}()
+
+	query := getSqliteSafetyQuery(sqlite3Database, credentials.Username, splitURL[4])
+
+	_ = os.Remove("tempDatabase.db")
+	return template.HTML(query), false //change to out desired output
+}
+
+// setupSqlite3 helper function to initialize the database
+// closing db connection is executed in the context where it's used
+func setupSqlite3() (*sql.DB, error) {
 	_ = os.Remove("tempDatabase.db")
 	log.Println("Creating tempDatabase.db...")
 	file, err := os.Create("tempDatabase.db")
 	if err != nil {
 		log.Println(err)
-		return template.HTML(err.Error()), false
+		return nil, err
 	}
 	_ = file.Close()
 	log.Println("tempDatabase.db created")
 	sqlite3Database, _ := sql.Open("sqlite3", "./tempDatabase.db")
 
-	defer func() {
-		_ = sqlite3Database.Close()
-	}()
+	return sqlite3Database, nil
+}
 
+func getSqliteSafetyQuery(db *sql.DB, userInput, safety string) string{
 	var query string
-	userInput := utils.GetUserInput(r)
-
-	switch splitURL[4] {
+	switch safety {
 	case "unsafe":
 		query = fmt.Sprintf("SELECT '%s' as '%s'", userInput, "test")
-		res, err := sqlite3Database.Exec(query)
+		res, err := db.Exec(query)
 		log.Println("Result: ", res, " Error: ", err)
 	case "safe":
 		// Safe uses a parameterized query which is built by exec from
 		// parameters which are passed in along with a static query string
 		query = "SELECT '?' as '?'"
-		res, err := sqlite3Database.Exec(query, userInput, "test")
+		res, err := db.Exec(query, userInput, "test")
 		log.Println("Result: ", res, " Error: ", err)
 	default:
-		log.Println(splitURL[4])
+		log.Println(safety)
 	}
+
+	return query
+}
+
+func sqlite3Handler(w http.ResponseWriter, r *http.Request, routeInfo utils.Route, splitURL []string) (template.HTML, bool) {
+	sqlite3Database, err := setupSqlite3()
+	if err != nil {
+		return template.HTML(err.Error()), false
+	}
+	defer func() {
+		_ = sqlite3Database.Close()
+	}()
+
+	userInput := utils.GetUserInput(r)
+	query := getSqliteSafetyQuery(sqlite3Database, userInput, splitURL[4])
+
 	_ = os.Remove("tempDatabase.db")
 	return template.HTML(query), false //change to out desired output
 }
@@ -73,16 +121,20 @@ func sqlite3Handler(w http.ResponseWriter, r *http.Request, routeInfo utils.Rout
 func Handler(w http.ResponseWriter, r *http.Request, pd utils.Parameters) (template.HTML, bool) {
 	splitURL := strings.Split(r.URL.Path, "/")
 	if len(splitURL) < 4 {
-		return sqliTemplate(w, r, pd.Rulebar[pd.Name])
+		return sqliTemplate(w, r, pd)
 	}
 	if splitURL[4] == "noop" {
 		return template.HTML("NOOP"), false
 	}
+	if splitURL[2] == "headers" {
+		return headersHandler(w, r, pd.Rulebar[pd.Name], splitURL)
+	}
+
 	switch splitURL[3] {
 	case "sqlite3Exec":
 		return sqlite3Handler(w, r, pd.Rulebar[pd.Name], splitURL)
 	case "":
-		return sqliTemplate(w, r, pd.Rulebar[pd.Name])
+		return sqliTemplate(w, r, pd)
 	default:
 		log.Fatal("sqlInjection Handler reached incorrectly")
 		return "", false

--- a/views/pages/sqlInjection.gohtml
+++ b/views/pages/sqlInjection.gohtml
@@ -1,8 +1,19 @@
 {{define "sqlInjection"}}
-<h1 class="page-header">{{.Name}}</h1>
-{{template "ruleInfo" .}}
-{{$base := .Base}}
-{{range .Sinks}}
+{{$routeInfo := index .Rulebar .Name}}
+{{$base := $routeInfo.Base}}
+{{$port := .Port}}
+{{$inputs := $routeInfo.Inputs}}
+<h1 class="page-header">{{$routeInfo.Name}}</h1>
+{{template "ruleInfo" $routeInfo}}
+<div class="row">
+  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
+    <h4 class="sub-header">Headers - JSON</h4>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/unsafe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/safe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/noop -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+  </div>
+</div>
+{{range $routeInfo.Sinks}}
 <div class="row">
   <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
     <h4 class="sub-header">

--- a/views/pages/sqlInjection.gohtml
+++ b/views/pages/sqlInjection.gohtml
@@ -5,20 +5,17 @@
 {{$inputs := $routeInfo.Inputs}}
 <h1 class="page-header">{{$routeInfo.Name}}</h1>
 {{template "ruleInfo" $routeInfo}}
-<div class="row">
-  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
-    <h4 class="sub-header">Headers - JSON</h4>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/unsafe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/safe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/noop -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
-  </div>
-</div>
 {{range $routeInfo.Sinks}}
 <div class="row">
   <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
     <h4 class="sub-header">
       <code>{{.Name}}</code>
     </h4>
+    <h4 class="sub-header">Headers - JSON</h4>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/unsafe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/safe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/noop -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <h4 class="sub-header">Query</h4>
     <form method="{{.Method}}" action="{{$base}}{{.URL}}/unsafe" target="_blank">
       <div class="form-group">
         <label>SELECT '${input}' as 'test';</label>

--- a/views/routes.json
+++ b/views/routes.json
@@ -85,7 +85,7 @@
         "name"     :  "SQL Injection",
         "link"     :  "https://www.owasp.org/index.php/SQL_Injection",
         "products" :  ["Assess", "Protect"],
-        "inputs"   :  ["query"], 
+        "inputs"   :  ["query", "headers"],
         "sinks"    :  [
             {
                 "name"   : "sqlit3.exec",


### PR DESCRIPTION
Add new endpoint - `/sqlInjection/headers/json` to handle usage of json struct passed in a `credentials` header.

Update signature of `sqliTemplate` to pass page parameters used in the view template instead of routeInfo.

Extracted sqlite db setup and handling safety method for SQL Injection so new functions could be reused at both places - _headersHandler_ and _sqlite3Handler_.

#### Testing
Build and run the **go-test-bench** app. You should see a new section _Headers - JSON_ where you can get the curl request to be executed. A json field is used as a user input instead of header value directly.