### PR TITLE
Go 640 Read request body

### DIFF
--- a/views/pages/sqlInjection.gohtml
+++ b/views/pages/sqlInjection.gohtml
@@ -12,11 +12,19 @@
       <code>{{.Name}}</code>
     </h4>
     <h4 class="sub-header">Headers - JSON</h4>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/unsafe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/safe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
-    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/json/noop -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/sqlite3Exec/unsafe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/sqlite3Exec/safe -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
+    <p><pre>curl http://localhost{{$port}}{{$base}}/{{index $inputs 1}}/sqlite3Exec/noop -X POST -H "Content-Type: application/json" -H "credentials:{\"username\":\"Robert'; DROP TABLE Students;--\",\"password\":\"12345Pass\"}"</pre></p>
     <h4 class="sub-header">Query</h4>
     <form method="{{.Method}}" action="{{$base}}{{.URL}}/unsafe" target="_blank">
+      <div class="form-group">
+        <label>SELECT '${input}' as 'test';</label>
+        <input name="input" class="form-control" value="Robert&apos;; DROP TABLE Students;--" />
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+    <h4 class="sub-header">Body</h4>
+    <form method="POST" action="{{$base}}/{{index $inputs 2}}/sqlite3Exec/unsafe" target="_blank">
       <div class="form-group">
         <label>SELECT '${input}' as 'test';</label>
         <input name="input" class="form-control" value="Robert&apos;; DROP TABLE Students;--" />

--- a/views/routes.json
+++ b/views/routes.json
@@ -85,7 +85,7 @@
         "name"     :  "SQL Injection",
         "link"     :  "https://www.owasp.org/index.php/SQL_Injection",
         "products" :  ["Assess", "Protect"],
-        "inputs"   :  ["query", "headers"],
+        "inputs"   :  ["query", "headers-json", "body"],
         "sinks"    :  [
             {
                 "name"   : "sqlit3.exec",


### PR DESCRIPTION
Add new endpoint - `/sqlInjection/body/sqlite3Exec` to handle usage of **http.request.Body.Read** method to get the user input.

Update endpoint - `/sqlInjection/headers/json` to `/sqlInjection/headers-json/sqlite3Exec` so it follows to common convention.

Refactored sqlite db setup and handling safety method for SQL Injection. Setting up the database, opening the connection, execution of the specific query (safe or unsafe) happens in one function which is used in different sources for that sink.

### Testing
Build and run the go-test-bench app. You should see a new section **Body** where you can submit a form which uses the Read method of request.Body. You should see the vulnerability reported in Teamserver.