### PR TITLE
GO 685 Response write xss

### DIFF
--- a/nosql/nosql-injection.go
+++ b/nosql/nosql-injection.go
@@ -34,7 +34,7 @@ func MongoInit() {
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://root:rootpassword@mongo:27017"))
 	if err != nil {
-		log.Printf("Could not connect the Mongo client: err = %s",err)
+		log.Printf("Could not connect the Mongo client: err = %s", err)
 	}
 	mongoDB = mongoClient.Database("go-test-bench")
 	collection = mongoDB.Collection("colors")

--- a/utils/input.go
+++ b/utils/input.go
@@ -44,7 +44,6 @@ func GetUserInput(r *http.Request) string {
 	return ""
 }
 
-
 //GetParamValue returns the input value for the given key of a GET request query
 func GetParamValue(r *http.Request, key string) string {
 	return r.URL.Query().Get(key)

--- a/utils/input_test.go
+++ b/utils/input_test.go
@@ -18,7 +18,7 @@ func TestGetUserInput_GetParamValue(t *testing.T) {
 
 func TestGetUserInput_GetFormValue(t *testing.T) {
 	desiredVal := "form_value"
-	request := getMockRequest(t, http.MethodPost, "/form/testing", "input=" + desiredVal)
+	request := getMockRequest(t, http.MethodPost, "/form/testing", "input="+desiredVal)
 
 	request.Header.Set("Content-type", "application/x-www-form-urlencoded")
 
@@ -78,7 +78,7 @@ func TestGetPathValue(t *testing.T) {
 
 func TestGetFormValue(t *testing.T) {
 	desiredVal := "form_value"
-	request := getMockRequest(t, http.MethodPost, "/form/testing", "input=" + desiredVal)
+	request := getMockRequest(t, http.MethodPost, "/form/testing", "input="+desiredVal)
 
 	request.Header.Set("Content-type", "application/x-www-form-urlencoded")
 

--- a/views/pages/xss.gohtml
+++ b/views/pages/xss.gohtml
@@ -140,7 +140,7 @@
         <input
                 name="input"
                 class="form-control"
-                value="&lt;script&gt;alert('response writer');&lt;/script&gt;"
+                value="&lt;script&gt;alert('http.Response.Write');&lt;/script&gt;"
         />
       </div>
       <button type="submit" class="btn btn-primary">Submit</button>

--- a/views/pages/xss.gohtml
+++ b/views/pages/xss.gohtml
@@ -131,5 +131,21 @@
     </form>
   </div>
 </div>
+<div class="row">
+  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
+    <h4 class="sub-header">Response</h4>
+    <form method="POST" action="/xss/response/reflectedXss/unsafe" target="_blank">
+      <div class="form-group">
+        <label for="">input</label>
+        <input
+                name="input"
+                class="form-control"
+                value="&lt;script&gt;alert('response writer');&lt;/script&gt;"
+        />
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+  </div>
+</div>
 {{template "safeButtons" .}}
 {{end}}

--- a/xss/xss.go
+++ b/xss/xss.go
@@ -128,6 +128,26 @@ func bufferedBodyHandler(w http.ResponseWriter, r *http.Request, safety string) 
 	return template.HTML(input), false
 }
 
+func responseHandler(w http.ResponseWriter, r *http.Request, safety string) (template.HTML, bool) {
+	userInput := utils.GetUserInput(r)
+	var ret []byte
+	switch safety {
+	case "safe":
+		userInput = url.QueryEscape(userInput)
+		ret = []byte(userInput)
+		w.Write(ret)
+	case "unsafe":
+		ret = []byte(userInput)
+		w.Write(ret)
+	case "noop":
+		return template.HTML("NOOP"), false
+	default:
+		log.Fatal("Error running responseHandler. No option passed")
+	}
+
+	return template.HTML(""), false
+}
+
 func xssTemplate(w http.ResponseWriter, r *http.Request, pd utils.Parameters) (template.HTML, bool) {
 	var buf bytes.Buffer
 
@@ -152,6 +172,8 @@ func Handler(w http.ResponseWriter, r *http.Request, pd utils.Parameters) (templ
 		return bodyHandler(w, r, splitURL[4])
 	case "buffered-body":
 		return bufferedBodyHandler(w, r, splitURL[4])
+	case "response":
+		return responseHandler(w, r, splitURL[4])
 	default:
 		return xssTemplate(w, r, pd)
 	}

--- a/xss/xss.go
+++ b/xss/xss.go
@@ -130,15 +130,12 @@ func bufferedBodyHandler(w http.ResponseWriter, r *http.Request, safety string) 
 
 func responseHandler(w http.ResponseWriter, r *http.Request, safety string) (template.HTML, bool) {
 	userInput := utils.GetUserInput(r)
-	var ret []byte
 	switch safety {
 	case "safe":
 		userInput = url.QueryEscape(userInput)
-		ret = []byte(userInput)
-		w.Write(ret)
+		w.Write([]byte(userInput))
 	case "unsafe":
-		ret = []byte(userInput)
-		w.Write(ret)
+		w.Write([]byte(userInput))
 	case "noop":
 		return template.HTML("NOOP"), false
 	default:


### PR DESCRIPTION
Add new endpoint - `/xss/response/reflectedXss` to handle usage of **net/http.Response.Write**.

### Testing
Build and run the go-test-bench app. You should see a new section **Response** in Reflected XSS where you can submit a form which builds a Response and writes it into a buffer. The page response remains the userInput which is used to build the response.Body. You should see the vulnerability reported in Teamserver.