### PR TITLE
user input as arg 0, change default listen addr for docker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	ehden.sinai@contrastsecurity.com benji.vesterby@contrastsecurity.com alex.hernandez@contrastsecurity.com james.roberts@contrastsecurity.com
+*	ehden.sinai@contrastsecurity.com benji.vesterby@contrastsecurity.com alex.hernandez@contrastsecurity.com james.roberts@contrastsecurity.com 93549255+mark-pictor-csec@users.noreply.github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ COPY --from=builder /build/fakepasswd /etc/passwd
 
 EXPOSE 8080
 
-ENTRYPOINT ["/go-test-bench"]
+# default listen address of localhost:8080 does not work
+ENTRYPOINT ["/go-test-bench", "-addr=:8080"]

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -40,4 +40,4 @@ COPY --from=builder /build/app ./app
 COPY --from=builder /build/fakepasswd /etc/passwd
 
 # Execute the testbench agent
-ENTRYPOINT ["./app"]
+ENTRYPOINT ["./app", "-addr=:8080"]

--- a/cmd/gin/app.go
+++ b/cmd/gin/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -10,16 +9,15 @@ import (
 	"github.com/Contrast-Security-OSS/go-test-bench/pkg/servegin"
 )
 
-// DefaultPort is the port that the API runs on if no command line argument is specified
-const DefaultPort = 8080
+// DefaultPort is the port that the API runs on if not overridden with '-addr' flag
+const DefaultPort = "localhost:8080"
 
 func main() {
-	// Setup command line flags
-	port := flag.Int("port", DefaultPort, "listen on this `port` on localhost")
+	// set up command line flag
+	addr := flag.String("addr", DefaultPort, "listen on this `host:port`")
 	flag.Parse()
-	addr := fmt.Sprintf(":%d", *port)
 
-	router, dbFile := servegin.Setup(addr)
+	router, dbFile := servegin.Setup(*addr)
 
 	// graceful shutdown to clean up database file
 	quit := make(chan os.Signal, 1)
@@ -34,6 +32,6 @@ func main() {
 		os.Exit(0)
 	}()
 
-	log.Printf("Server startup at: %s\n", addr)
-	log.Fatal(router.Run(addr))
+	log.Printf("Server startup at: %s\n", *addr)
+	log.Fatal(router.Run(*addr))
 }

--- a/cmd/gin/app.go
+++ b/cmd/gin/app.go
@@ -9,12 +9,12 @@ import (
 	"github.com/Contrast-Security-OSS/go-test-bench/pkg/servegin"
 )
 
-// DefaultPort is the port that the API runs on if not overridden with '-addr' flag
-const DefaultPort = "localhost:8080"
+// DefaultAddr is where we listen if not overridden with '-addr' flag
+const DefaultAddr = "localhost:8080"
 
 func main() {
 	// set up command line flag
-	addr := flag.String("addr", DefaultPort, "listen on this `host:port`")
+	addr := flag.String("addr", DefaultAddr, "listen on this `host:port`")
 	flag.Parse()
 
 	router, dbFile := servegin.Setup(*addr)

--- a/cmd/std/app.go
+++ b/cmd/std/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -10,15 +9,14 @@ import (
 	"github.com/Contrast-Security-OSS/go-test-bench/pkg/servestd"
 )
 
-// DefaultPort is the port that the API runs on if no command line argument is specified
-const DefaultPort = 8080
+// DefaultPort is the port that the API runs on if not overridden with '-addr' flag
+const DefaultPort = "localhost:8080"
 
 func main() {
-	// set up command line flag
-	port := flag.Int("port", DefaultPort, "listen on this `port` on localhost")
+	// set up command line flags
+	flag.StringVar(&servestd.Pd.Addr, "addr", DefaultPort, "listen on this `host:port`")
 	flag.BoolVar(&common.Verbose, "v", true, "increase verbosity")
 	flag.Parse()
-	servestd.Pd.Addr = fmt.Sprintf(":%d", *port)
 
 	servestd.Setup()
 	log.Fatal(http.ListenAndServe(servestd.Pd.Addr, nil))

--- a/cmd/std/app.go
+++ b/cmd/std/app.go
@@ -9,12 +9,12 @@ import (
 	"github.com/Contrast-Security-OSS/go-test-bench/pkg/servestd"
 )
 
-// DefaultPort is the port that the API runs on if not overridden with '-addr' flag
-const DefaultPort = "localhost:8080"
+// DefaultAddr is where we listen if not overridden with '-addr' flag
+const DefaultAddr = "localhost:8080"
 
 func main() {
 	// set up command line flags
-	flag.StringVar(&servestd.Pd.Addr, "addr", DefaultPort, "listen on this `host:port`")
+	flag.StringVar(&servestd.Pd.Addr, "addr", DefaultAddr, "listen on this `host:port`")
 	flag.BoolVar(&common.Verbose, "v", true, "increase verbosity")
 	flag.Parse()
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/gin-contrib/multitemplate v0.0.0-20210428235909-8a2f6dd269a0
 	github.com/gin-gonic/gin v1.7.4
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	go.mongodb.org/mongo-driver v1.7.2
 	golang.org/x/sys v0.0.0-20210921065528-437939a70204 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/gin-contrib/multitemplate v0.0.0-20210428235909-8a2f6dd269a0
 	github.com/gin-gonic/gin v1.7.4
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	go.mongodb.org/mongo-driver v1.7.2
 	golang.org/x/sys v0.0.0-20210921065528-437939a70204 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=


### PR DESCRIPTION
* Make a change to the command execution example so that arg 0 is attacker-controlled.
* Docker needs to listen on `:8080`, but outside of docker that exposes the machine to attackers on the local network.
Change the `-port` flag to `-addr`, allowing host and port to be specified. In the Dockerfile, the default `localhost:8080` is overridden with `:8080`.