### PR TITLE
GO-1031 Create a vulnerability for the reflectedXss/unsafe endpoint

### DIFF
--- a/internal/xss/xss.go
+++ b/internal/xss/xss.go
@@ -33,14 +33,8 @@ func queryHandler(w http.ResponseWriter, r *http.Request, safety string) (templa
 
 // bufferedQueryHandler used as a handler which uses bytes.Buffer for source input ignoring the user input
 func bufferedQueryHandler(w http.ResponseWriter, r *http.Request, safety string) (template.HTML, bool) {
-	// FIXME(GO-1031): This buffer is populated with constant strings. There is no vulnerability here.
 	var buf bytes.Buffer
-	buf.Write([]byte("<script>"))
-	buf.WriteString("alert('buffered input - ")
-	buf.WriteRune('©')
-	buf.WriteString("');")
-	buf.WriteString("</script")
-	buf.WriteByte(byte('>'))
+	buf.WriteString(common.GetUserInput(r))
 
 	var input string
 


### PR DESCRIPTION
The endpoint `reflectedXss/unsafe` is meant to contain a vulnerability which could be displayed as a finding in TS. 
Previously the bufferedQueryHandler always passed hardcoded data for the call to `template.HTML(input)`, making that call actually safe. The change here gives user input to template.HTML to create a vulnerability.