### PR TITLE
GO-1433: Upgrade to 1.19 and revert mingw downgrade

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Run gofmt
         run: gofmt -s .
       - name: Execute golint
@@ -36,12 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
-      - name: windows - downgrade mingw to 10.2.0
-        # TODO (GO-1433) revert once 'go test -race' issue is fixed
-        # see https://github.com/golang/go/issues/46099 and maybe https://github.com/golang/go/issues/35006
-        if: ${{ matrix.platform == 'windows-latest' }}
-        run: choco install mingw --version 10.2.0 --allow-downgrade
+          go-version: 1.19
       - name: Test
         run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Push Coverage to codecov.io
@@ -52,7 +47,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.17, 1.18]
+        go-version: [1.18, 1.19]
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: true
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
The windows ThreadSanitizer issue has been fixed in go1.19.