### PR TITLE
GO-1959: fix unsafe cmdi handler

### DIFF
--- a/internal/injection/cmdi/cmd-injection.go
+++ b/internal/injection/cmdi/cmd-injection.go
@@ -32,7 +32,7 @@ func RegisterRoutes(frameworkSinks ...*common.Sink) {
 		Products: []string{"Assess", "Protect"},
 		Inputs:   []string{"query", "cookies"},
 		Sinks:    sinks,
-		Payload:  "hello there! && echo hack hack hack",
+		Payload:  "echo hello there! && echo hack hack hack",
 	})
 }
 


### PR DESCRIPTION
Originally, the default cmdi payload did not form a valid command
when using the unsafe handler. This was fine for assess, but not for
protect. Protect will only block if the command tries to run. This
would not happen if the command name (previously "hello") was not
found in the PATH. To avoid confusing end users, the default cmdi
payload has been changed to a valid command.