### PR TITLE
pipelines: fix broken pipelines from previous commit

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -6,13 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-<<<<<<< HEAD
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@v2
-=======
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@6c1fd22b67f7a7c42ad9a45c0f4197434035e429 # v5
->>>>>>> main
         with:
           go-version: "1.23"
       - name: Run gofmt


### PR DESCRIPTION
The last PR had a merge conflict with main. I thought I had it resolved, but it turns out I missed one. I'm honestly surprised that both VSCode and Github let me merge a PR that still had a conflict. I guess the text highlighting the conflict was just naively added to the workflow file. This broke the file of course, but it still let me merge. Very strange. Anyway, let's fix this.